### PR TITLE
fix: remove unused setAuthor function

### DIFF
--- a/toc.go
+++ b/toc.go
@@ -234,10 +234,6 @@ func (t *toc) setTitle(title string) {
 	t.title = title
 }
 
-func (t *toc) setAuthor(author string) {
-	t.author = author
-}
-
 // Write the TOC files
 func (t *toc) write(tempDir string) error {
 	err := t.writeNavDoc(tempDir)


### PR DESCRIPTION
this one remove last golangci error for unused `setAuthor` in `toc.go` file