### PR TITLE
fix: misplaced subsection position in toc.ncx (#12)

### DIFF
--- a/toc.go
+++ b/toc.go
@@ -214,7 +214,7 @@ func (t *toc) addSubSection(parent string, index int, title string, relativePath
 		},
 		Children: nil,
 	}
-	if parentNcxIndex > len(t.ncxXML.NavMap) {
+	if len(t.ncxXML.NavMap) > parentNcxIndex {
 		if t.ncxXML.NavMap[parentNcxIndex].Children == nil {
 			n := make([]tocNcxNavPoint, 0)
 			t.ncxXML.NavMap[parentNcxIndex].Children = &n


### PR DESCRIPTION
For toc.ncx in epub V2， a subsection navigate label should be placed under section label, while subsection is misplaced parallel to section. 

This is because function toc.addSubSection (toc.go: 173) used opposite condition for ncxXML. When there is parent section for subsection,  code goes into a situation assuming no parent section, which means taking this subsection as a lonely section.

So, simply exchange the condition would work.
And for code style consistency, use same style like navXML part (toc.go: 191).