### PR TITLE
 fix: Append subsection to subsection

### DIFF
--- a/epub.go
+++ b/epub.go
@@ -385,10 +385,9 @@ func (e *Epub) addSection(parentFilename string, body string, sectionTitle strin
 		e.sections = append(e.sections, s)
 	} else {
 		// find parent section and append subsection to that
-		sectionAppender(e.sections, parentFilename, s)
-
+		err := sectionAppender(e.sections, parentFilename, s)
 		if err != nil {
-			log.Println("i can't append subsection", err)
+			return "", err
 		}
 	}
 

--- a/pkg.go
+++ b/pkg.go
@@ -180,6 +180,7 @@ func (p *pkg) setAuthor(author string) {
 
 // Add an EPUB 2 cover meta element for backward compatibility (http://idpf.org/forum/topic-715)
 func (p *pkg) setCover(coverRef string) {
+	coverRef, _ = fixXMLId(coverRef)
 	p.coverMeta = &pkgMeta{
 		Name:    "cover",
 		Content: coverRef,

--- a/toc.go
+++ b/toc.go
@@ -3,6 +3,7 @@ package epub
 import (
 	"encoding/xml"
 	"fmt"
+	"log"
 	"path/filepath"
 	"strconv"
 )
@@ -188,8 +189,14 @@ func (t *toc) addSubSection(parent string, index int, title string, relativePath
 			},
 			Children: nil,
 		}
-		navAppender(t, parentRelativePath, l)
-		ncxAppender(t, parentRelativePath, *np)
+		err := navAppender(t, parentRelativePath, l)
+		if err != nil {
+			log.Println(err)
+		}
+		err = ncxAppender(t, parentRelativePath, *np)
+		if err != nil {
+			log.Println(err)
+		}
 	}
 }
 

--- a/toc.go
+++ b/toc.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"path/filepath"
+	"regexp"
 	"strconv"
 )
 
@@ -228,7 +229,14 @@ func (t *toc) writeNavDoc(tempDir string) error {
 		return fmt.Errorf("Error marshalling XML for EPUB v3 TOC file: %w\n"+"\tXML=%#v", err, t.navXML)
 	}
 
-	n, err := newXhtml(string(navBodyContent))
+	// subsection without children itself left an empty tag <ol></ol>
+	// that not acceptable for epub v3
+	// this regex will remove those line from tocnav.
+	// TODO: find a better solution
+	re := regexp.MustCompile(`\s*<ol>\s*</ol>`)
+	bodyWithoutEmptyTags := re.ReplaceAllString(string(navBodyContent), "")
+
+	n, err := newXhtml(bodyWithoutEmptyTags)
 	if err != nil {
 		return fmt.Errorf("can't create xhtml for TOC file: %w", err)
 	}

--- a/write.go
+++ b/write.go
@@ -431,7 +431,10 @@ func (e *Epub) writeSections(rootEpubDir string) {
 		if e.cover.xhtmlFilename != "" {
 			e.pkg.addToSpine(e.cover.xhtmlFilename)
 		}
-		writeSections(rootEpubDir, e, e.sections, parentlis, filenamelist)
+		err := writeSections(rootEpubDir, e, e.sections, parentlis, filenamelist)
+		if err != nil {
+			log.Println(err)
+		}
 	}
 }
 

--- a/write.go
+++ b/write.go
@@ -510,7 +510,10 @@ func writeSections(rootEpubDir string, e *Epub, sections []epubSection, parentfi
 			e.toc.addSubSection(parentfilenameis, j, section.xhtml.Title(), relativePath)
 		}
 		if section.children != nil {
-			writeSections(rootEpubDir, e, section.children, parentfilename, filenamelist)
+			err = writeSections(rootEpubDir, e, section.children, parentfilename, filenamelist)
+			if err != nil {
+				log.Println(err)
+			}
 		}
 	}
 


### PR DESCRIPTION
As mentioned in bug report #16, `go-epub` can't append a subsection to a subsection.
Another bug we found is that currently `go-epub` cannot append section to morethan level one.
This PR will fix these bugs and refactor the logic for a better approach.
# TODO:
- [x] update `epub.go`
- [x] update `write.go`
- [x] update `toc.go`
- [x] add function that we need
- [x] handle cover in new logic
- [x] fix golangci errors
- [x] fix test-epubcheck
- [x] better name function and comment
- [ ] update unit tests 
*currently fixing this bug on my local machine, this todo list will be complete when I add more commits*.