### PR TITLE
allow writing and assembling unzipped directory structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 - Creates valid EPUB 3.0 files
 - Adds an additional EPUB 2.0 table of contents for maximum compatibility
 - Includes support for adding CSS, images, and fonts
+- Supports writing exploded EPUB directories for inspection and manual modification
+- Can assemble exploded EPUB directories back into zipped EPUB files
 
 ### Contributions
 

--- a/write.go
+++ b/write.go
@@ -51,6 +51,60 @@ const (
 	xhtmlFolderName   = "xhtml"
 )
 
+// writeContent writes all EPUB content to the specified root directory.
+// This is the core logic shared by WriteTo and WriteDirectory.
+func (e *Epub) writeContent(rootDir string) error {
+
+	// The order in which the file is assembled matters for some files.
+	// Containers, CSS, media, and sections can only be written after the
+	// necessary folders are created (createEPubFolders).
+	// The TOC must be written after all sections have been written.
+	// The package file is the final file to be written.
+	err := writeMimetype(rootDir)
+	if err != nil {
+		return err
+	}
+	err = createEpubFolders(rootDir)
+	if err != nil {
+		return err
+	}
+
+	err = writeContainerFile(rootDir)
+	if err != nil {
+		return err
+	}
+
+	err = e.writeCSSFiles(rootDir)
+	if err != nil {
+		return err
+	}
+
+	err = e.writeFonts(rootDir)
+	if err != nil {
+		return err
+	}
+
+	err = e.writeImages(rootDir)
+	if err != nil {
+		return err
+	}
+
+	err = e.writeVideos(rootDir)
+	if err != nil {
+		return err
+	}
+
+	err = e.writeAudios(rootDir)
+	if err != nil {
+		return err
+	}
+
+	e.writeSections(rootDir)
+	e.writeToc(rootDir)
+	e.writePackageFile(rootDir)
+	return nil
+}
+
 // WriteTo the dest io.Writer. The return value is the number of bytes written. Any error encountered during the write is also returned.
 func (e *Epub) WriteTo(dst io.Writer) (int64, error) {
 	e.Lock()
@@ -67,77 +121,43 @@ func (e *Epub) WriteTo(dst io.Writer) (int64, error) {
 			log.Print("Error removing temp directory: %w", err)
 		}
 	}()
-	err = writeMimetype(tempDir)
-	if err != nil {
-		return 0, err
-	}
-	err = createEpubFolders(tempDir)
-	if err != nil {
-		return 0, err
-	}
 
-	// Must be called after:
-	// createEpubFolders()
-	err = writeContainerFile(tempDir)
+	err = e.writeContent(tempDir)
 	if err != nil {
 		return 0, err
 	}
 
-	// Must be called after:
-	// createEpubFolders()
-	err = e.writeCSSFiles(tempDir)
-	if err != nil {
-		return 0, err
-	}
-
-	// Must be called after:
-	// createEpubFolders()
-	err = e.writeFonts(tempDir)
-	if err != nil {
-		return 0, err
-	}
-
-	// Must be called after:
-	// createEpubFolders()
-	err = e.writeImages(tempDir)
-	if err != nil {
-		return 0, err
-	}
-
-	// Must be called after:
-	// createEpubFolders()
-	err = e.writeVideos(tempDir)
-	if err != nil {
-		return 0, err
-	}
-
-	// Must be called after:
-	// createEpubFolders()
-	err = e.writeAudios(tempDir)
-	if err != nil {
-		return 0, err
-	}
-
-	// Must be called after:
-	// createEpubFolders()
-	e.writeSections(tempDir)
-
-	// Must be called after:
-	// createEpubFolders()
-	// writeSections()
-	e.writeToc(tempDir)
-
-	// Must be called after:
-	// createEpubFolders()
-	// writeCSSFiles()
-	// writeImages()
-	// writeVideos()
-	// writeAudios()
-	// writeSections()
-	// writeToc()
-	e.writePackageFile(tempDir)
-	// Must be called last
 	return e.writeEpub(tempDir, dst)
+}
+
+// WriteDirectory writes the EPUB as an exploded directory structure for inspection,
+// manual modification, and debugging. The destDir must be a path to a directory
+// (which will be created if it doesn't exist).
+func (e *Epub) WriteDirectory(destDir string) error {
+	e.Lock()
+	defer e.Unlock()
+
+	// Create a temp directory using the existing filesystem abstraction (like WriteTo does)
+	tempDir := uuid.Must(uuid.NewV4()).String()
+
+	err := filesystem.Mkdir(tempDir, dirPermissions)
+	if err != nil {
+		return fmt.Errorf("Error creating temp directory: %w", err)
+	}
+	defer func() {
+		if err := filesystem.RemoveAll(tempDir); err != nil {
+			log.Print("Error removing temp directory: %w", err)
+		}
+	}()
+
+	// Write EPUB content to temp directory using the existing abstraction
+	err = e.writeContent(tempDir)
+	if err != nil {
+		return err
+	}
+
+	// Copy the assembled temp directory to the destination directory
+	return copyDirectory(tempDir, destDir)
 }
 
 // Write writes the EPUB file. The destination path must be the full path to
@@ -155,6 +175,55 @@ func (e *Epub) Write(destFilePath string) error {
 	defer f.Close()
 	_, err = e.WriteTo(f)
 	return err
+}
+
+// copyDirectory recursively copies a directory from the filesystem abstraction to the OS filesystem.
+func copyDirectory(srcDir, destDir string) error {
+	// Create destination directory
+	err := os.MkdirAll(destDir, dirPermissions)
+	if err != nil {
+		return fmt.Errorf("Error creating destination directory: %w", err)
+	}
+
+	// Walk the source directory and copy all files
+	return fs.WalkDir(filesystem, srcDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Get relative path from source root
+		relPath, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return err
+		}
+
+		destPath := filepath.Join(destDir, relPath)
+
+		if d.IsDir() {
+			// Create directory in destination
+			return os.MkdirAll(destPath, dirPermissions)
+		}
+
+		// Copy file
+		srcFile, err := filesystem.Open(path)
+		if err != nil {
+			return fmt.Errorf("Error opening source file %s: %w", path, err)
+		}
+		defer srcFile.Close()
+
+		destFile, err := os.Create(destPath)
+		if err != nil {
+			return fmt.Errorf("Error creating destination file %s: %w", destPath, err)
+		}
+		defer destFile.Close()
+
+		_, err = io.Copy(destFile, srcFile)
+		if err != nil {
+			return fmt.Errorf("Error copying file %s: %w", path, err)
+		}
+
+		return nil
+	})
 }
 
 // Create the EPUB folder structure in a temp directory
@@ -237,6 +306,144 @@ func (wc *writeCounter) Write(p []byte) (int, error) {
 	n := len(p)
 	wc.Total += int64(n)
 	return n, nil
+}
+
+// AssembleDirectory assembles an exploded EPUB directory into a zipped EPUB file.
+// The sourceDir must be a path to a directory containing a valid exploded EPUB structure
+// (with mimetype, META-INF/container.xml, and EPUB/ folders).
+// The destFilePath must be the full path to the resulting EPUB file, including filename and extension.
+func AssembleDirectory(sourceDir, destFilePath string) error {
+	// Verify the source directory exists
+	info, err := os.Stat(sourceDir)
+	if err != nil {
+		return fmt.Errorf("Error accessing source directory: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("Source path is not a directory: %s", sourceDir)
+	}
+
+	// Verify required files/folders exist
+	mimetypePath := filepath.Join(sourceDir, mimetypeFilename)
+	if _, err := os.Stat(mimetypePath); os.IsNotExist(err) {
+		return fmt.Errorf("Invalid EPUB directory: missing mimetype file")
+	}
+
+	containerPath := filepath.Join(sourceDir, metaInfFolderName, containerFilename)
+	if _, err := os.Stat(containerPath); os.IsNotExist(err) {
+		return fmt.Errorf("Invalid EPUB directory: missing META-INF/container.xml")
+	}
+
+	// Create the destination EPUB file
+	f, err := os.Create(destFilePath)
+	if err != nil {
+		return &UnableToCreateEpubError{
+			Path: destFilePath,
+			Err:  err,
+		}
+	}
+	defer f.Close()
+
+	// Use the writeEpubFromDirectory helper to zip the directory
+	_, err = writeEpubFromDirectory(sourceDir, f)
+	return err
+}
+
+// writeEpubFromDirectory is a helper that zips an exploded EPUB directory to an io.Writer.
+// It's similar to writeEpub but works with an existing directory instead of a temp directory.
+func writeEpubFromDirectory(rootEpubDir string, dst io.Writer) (int64, error) {
+	counter := &writeCounter{}
+	teeWriter := io.MultiWriter(counter, dst)
+
+	z := zip.NewWriter(teeWriter)
+
+	skipMimetypeFile := false
+
+	// addFileToZip adds the file present at path to the zip archive
+	addFileToZip := func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Get the path of the file relative to the folder we're zipping
+		relativePath, err := filepath.Rel(rootEpubDir, path)
+		if err != nil {
+			return err
+		}
+		relativePath = filepath.ToSlash(relativePath)
+
+		// Only include regular files, not directories
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+
+		var w io.Writer
+		if filepath.FromSlash(path) == filepath.Join(rootEpubDir, mimetypeFilename) {
+			// Skip the mimetype file if it's already been written
+			if skipMimetypeFile {
+				return nil
+			}
+			// The mimetype file must be uncompressed according to the EPUB spec
+			w, err = z.CreateHeader(&zip.FileHeader{
+				Name:   relativePath,
+				Method: zip.Store,
+			})
+		} else {
+			w, err = z.Create(relativePath)
+		}
+		if err != nil {
+			return fmt.Errorf("error creating zip writer: %w", err)
+		}
+
+		r, err := os.Open(path)
+		if err != nil {
+			return fmt.Errorf("error opening file %v being added to EPUB: %w", path, err)
+		}
+		defer func() {
+			if err := r.Close(); err != nil {
+				log.Println(err)
+			}
+		}()
+
+		_, err = io.Copy(w, r)
+		if err != nil {
+			return fmt.Errorf("error copying contents of file being added EPUB: %w", err)
+		}
+		return nil
+	}
+
+	// Add the mimetype file first
+	mimetypeFilePath := filepath.Join(rootEpubDir, mimetypeFilename)
+	mimetypeInfo, err := os.Stat(mimetypeFilePath)
+	if err != nil {
+		if err := z.Close(); err != nil {
+			log.Println(err)
+		}
+		return counter.Total, fmt.Errorf("unable to get FileInfo for mimetype file: %w", err)
+	}
+	err = addFileToZip(mimetypeFilePath, fileInfoToDirEntry(mimetypeInfo), nil)
+	if err != nil {
+		if err := z.Close(); err != nil {
+			log.Println(err)
+		}
+		return counter.Total, fmt.Errorf("unable to add mimetype file to EPUB: %w", err)
+	}
+
+	skipMimetypeFile = true
+
+	err = filepath.WalkDir(rootEpubDir, addFileToZip)
+	if err != nil {
+		if err := z.Close(); err != nil {
+			log.Println(err)
+		}
+		return counter.Total, fmt.Errorf("unable to add file to EPUB: %w", err)
+	}
+
+	err = z.Close()
+	return counter.Total, err
 }
 
 // Write the EPUB file itself by zipping up everything from a temp directory
@@ -439,7 +646,7 @@ func (e *Epub) writeSections(rootEpubDir string) {
 }
 
 // Write the TOC file to the temporary directory and add the TOC entries to the
-// package file
+// package file. All `writeSections` calls must be done before this.
 func (e *Epub) writeToc(rootEpubDir string) {
 	e.pkg.addToManifest(tocNavItemID, tocNavFilename, mediaTypeXhtml, tocNavItemProperties)
 	e.pkg.addToManifest(tocNcxItemID, tocNcxFilename, mediaTypeNcx, "")

--- a/write.go
+++ b/write.go
@@ -51,16 +51,43 @@ const (
 	xhtmlFolderName   = "xhtml"
 )
 
+// resetWriteState resets the TOC and package manifest/spine so that
+// the Epub can be written multiple times without accumulating duplicate entries
+func (e *Epub) resetWriteState() error {
+	// Reinitialize the TOC to clear any previous entries
+	var err error
+	e.toc, err = newToc()
+	if err != nil {
+		return fmt.Errorf("error resetting TOC: %w", err)
+	}
+	e.toc.setTitle(e.Title())
+	e.toc.setIdentifier(e.Identifier())
+
+	// Clear the manifest and spine from the package
+	// Keep metadata but reset the file lists
+	e.pkg.xml.ManifestItems = nil
+	e.pkg.xml.Spine.Items = nil
+
+	return nil
+}
+
 // writeContent writes all EPUB content to the specified root directory.
 // This is the core logic shared by WriteTo and WriteDirectory.
 func (e *Epub) writeContent(rootDir string) error {
+	// Reset TOC and package manifest/spine for multiple writes
+	// This ensures that calling Write/WriteDirectory multiple times on the same
+	// Epub instance doesn't accumulate duplicate entries
+	err := e.resetWriteState()
+	if err != nil {
+		return err
+	}
 
 	// The order in which the file is assembled matters for some files.
 	// Containers, CSS, media, and sections can only be written after the
 	// necessary folders are created (createEPubFolders).
 	// The TOC must be written after all sections have been written.
 	// The package file is the final file to be written.
-	err := writeMimetype(rootDir)
+	err = writeMimetype(rootDir)
 	if err != nil {
 		return err
 	}

--- a/write_test.go
+++ b/write_test.go
@@ -1,7 +1,9 @@
 package epub
 
 import (
+	"archive/zip"
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -238,7 +240,12 @@ func TestRoundTripDirectoryToZip(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tempDir := t.TempDir()
+	//tempDir := t.TempDir()
+
+	tempDir, err := os.MkdirTemp("", "test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Write as directory
 	epubDir := filepath.Join(tempDir, "test-epub")
@@ -261,25 +268,73 @@ func TestRoundTripDirectoryToZip(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Both files should exist and have reasonable sizes
-	info1, err := os.Stat(epubFile)
+	// Both files should be identical in content
+	// Compare zip file contents rather than raw bytes because
+	// timestamps and compression details may vary slightly
+	err = compareEpubFiles(epubFile, epubFile2)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
-	info2, err := os.Stat(epubFile2)
+
+}
+
+// compareEpubFiles compares two EPUB files by extracting and comparing their contents
+func compareEpubFiles(file1, file2 string) error {
+	z1, err := zip.OpenReader(file1)
 	if err != nil {
-		t.Fatal(err)
+		return fmt.Errorf("error opening %s: %w", file1, err)
+	}
+	defer z1.Close()
+
+	z2, err := zip.OpenReader(file2)
+	if err != nil {
+		return fmt.Errorf("error opening %s: %w", file2, err)
+	}
+	defer z2.Close()
+
+	if len(z1.File) != len(z2.File) {
+		return fmt.Errorf("different number of files: %d vs %d", len(z1.File), len(z2.File))
 	}
 
-	if info1.Size() == 0 {
-		t.Error("Assembled EPUB is empty")
-	}
-	if info2.Size() == 0 {
-		t.Error("Direct write EPUB is empty")
+	// Create maps of filename -> content for both zips
+	files1 := make(map[string][]byte)
+	for _, f := range z1.File {
+		rc, err := f.Open()
+		if err != nil {
+			return fmt.Errorf("error opening %s in first zip: %w", f.Name, err)
+		}
+		content, err := io.ReadAll(rc)
+		rc.Close()
+		if err != nil {
+			return fmt.Errorf("error reading %s in first zip: %w", f.Name, err)
+		}
+		files1[f.Name] = content
 	}
 
-	if info1.Size() != info2.Size() {
-		t.Logf("Assembled EPUB size: %d, Direct write EPUB size: %d", info1.Size(), info2.Size())
+	files2 := make(map[string][]byte)
+	for _, f := range z2.File {
+		rc, err := f.Open()
+		if err != nil {
+			return fmt.Errorf("error opening %s in second zip: %w", f.Name, err)
+		}
+		content, err := io.ReadAll(rc)
+		rc.Close()
+		if err != nil {
+			return fmt.Errorf("error reading %s in second zip: %w", f.Name, err)
+		}
+		files2[f.Name] = content
 	}
 
+	// Compare file contents
+	for name, content1 := range files1 {
+		content2, ok := files2[name]
+		if !ok {
+			return fmt.Errorf("file %s exists in first epub but not in second", name)
+		}
+		if !bytes.Equal(content1, content2) {
+			return fmt.Errorf("file %s has different content: %d bytes vs %d bytes", name, len(content1), len(content2))
+		}
+	}
+
+	return nil
 }

--- a/write_test.go
+++ b/write_test.go
@@ -92,3 +92,194 @@ func testWriteToErrors(t *testing.T, e *Epub, adder func(string, string) (string
 		t.Fatal("Expected error")
 	}
 }
+
+func TestWriteDirectory(t *testing.T) {
+	e, err := NewEpub("Test WriteDirectory")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e.SetAuthor("Test Author")
+	_, err = e.AddSection("<h1>Chapter 1</h1><p>Content here.</p>", "Chapter 1", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tempDir := t.TempDir()
+	println(tempDir)
+	epubDir := filepath.Join(tempDir, "test-epub")
+
+	err = e.WriteDirectory(epubDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the directory structure was created
+	expectedPaths := []string{
+		filepath.Join(epubDir, "mimetype"),
+		filepath.Join(epubDir, "META-INF", "container.xml"),
+		filepath.Join(epubDir, "EPUB", "package.opf"),
+		filepath.Join(epubDir, "EPUB", "xhtml"),
+	}
+
+	for _, path := range expectedPaths {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			t.Errorf("Expected path does not exist: %s", path)
+		}
+	}
+}
+
+func TestAssembleDirectory(t *testing.T) {
+	// First create an exploded EPUB directory
+	e, err := NewEpub("Test AssembleDirectory")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e.SetAuthor("Test Author")
+	_, err = e.AddSection("<h1>Chapter 1</h1><p>Content here.</p>", "Chapter 1", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tempDir := t.TempDir()
+	epubDir := filepath.Join(tempDir, "test-epub")
+
+	err = e.WriteDirectory(epubDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Now assemble it into a zipped EPUB
+	epubFile := filepath.Join(tempDir, "test.epub")
+	err = AssembleDirectory(epubDir, epubFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the EPUB file was created
+	info, err := os.Stat(epubFile)
+	if err != nil {
+		t.Fatalf("EPUB file was not created: %v", err)
+	}
+
+	if info.Size() == 0 {
+		t.Error("EPUB file is empty")
+	}
+}
+
+func TestAssembleDirectoryErrors(t *testing.T) {
+	tempDir := t.TempDir()
+
+	t.Run("NonExistentDirectory", func(t *testing.T) {
+		err := AssembleDirectory(filepath.Join(tempDir, "nonexistent"), filepath.Join(tempDir, "test.epub"))
+		if err == nil {
+			t.Error("Expected error for non-existent directory")
+		}
+	})
+
+	t.Run("NotADirectory", func(t *testing.T) {
+		// Create a file instead of a directory
+		filePath := filepath.Join(tempDir, "notadir")
+		if err := os.WriteFile(filePath, []byte("test"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		err := AssembleDirectory(filePath, filepath.Join(tempDir, "test.epub"))
+		if err == nil {
+			t.Error("Expected error for file instead of directory")
+		}
+	})
+
+	t.Run("MissingMimetype", func(t *testing.T) {
+		invalidDir := filepath.Join(tempDir, "invalid-epub")
+		if err := os.MkdirAll(invalidDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		err := AssembleDirectory(invalidDir, filepath.Join(tempDir, "test.epub"))
+		if err == nil {
+			t.Error("Expected error for missing mimetype file")
+		}
+	})
+
+	t.Run("MissingContainerXML", func(t *testing.T) {
+		invalidDir := filepath.Join(tempDir, "invalid-epub2")
+		if err := os.MkdirAll(invalidDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		// Create mimetype but not container.xml
+		if err := os.WriteFile(filepath.Join(invalidDir, "mimetype"), []byte("application/epub+zip"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		err := AssembleDirectory(invalidDir, filepath.Join(tempDir, "test.epub"))
+		if err == nil {
+			t.Error("Expected error for missing container.xml")
+		}
+	})
+}
+
+func TestRoundTripDirectoryToZip(t *testing.T) {
+	// Create an EPUB, write it to a directory, assemble it, and verify it's valid
+	e, err := NewEpub("Test RoundTrip")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e.SetAuthor("Test Author")
+	e.SetDescription("Test Description")
+	_, err = e.AddSection("<h1>Chapter 1</h1><p>First chapter.</p>", "Chapter 1", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = e.AddSection("<h1>Chapter 2</h1><p>Second chapter.</p>", "Chapter 2", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tempDir := t.TempDir()
+
+	// Write as directory
+	epubDir := filepath.Join(tempDir, "test-epub")
+	err = e.WriteDirectory(epubDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Assemble to zip
+	epubFile := filepath.Join(tempDir, "test.epub")
+	err = AssembleDirectory(epubDir, epubFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Write directly to zip for comparison
+	epubFile2 := filepath.Join(tempDir, "test2.epub")
+	err = e.Write(epubFile2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Both files should exist and have reasonable sizes
+	info1, err := os.Stat(epubFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info2, err := os.Stat(epubFile2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info1.Size() == 0 {
+		t.Error("Assembled EPUB is empty")
+	}
+	if info2.Size() == 0 {
+		t.Error("Direct write EPUB is empty")
+	}
+
+	if info1.Size() != info2.Size() {
+		t.Logf("Assembled EPUB size: %d, Direct write EPUB size: %d", info1.Size(), info2.Size())
+	}
+
+}


### PR DESCRIPTION
Added `WriteDirectory` and `AssembleDirectory` methods to allow working with unzipped ePub directory structures.
As described in #72

The changes are backwards compatible and tests are included for the functionality.

